### PR TITLE
Setting decimal places

### DIFF
--- a/onecall.js
+++ b/onecall.js
@@ -721,7 +721,7 @@ Module.register("onecall", {
 						if (this.config.units === "metric" || this.config.units === "default") {
 							visible.innerHTML =  forecast.visibility/1000 + " Km";
 						} else if (this.config.units === "imperial") {
-							visible.innerHTML =  (forecast.visibility/1000)/1.609344 + " mi";
+							visible.innerHTML =  Math.round(forecast.visibility/1000).toFixed(2) + " mi";
 						}
 						visible.className = "align-center violet visibility";
 						row.appendChild(visible);


### PR DESCRIPTION
For Extra Hours, the math create too many decimal places throwing the column width off.  The Api will return back the Imperial metrics if the configuration is set properly.  This should account for the conversion.